### PR TITLE
Updates to allow access from marbl-diags scripts

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,7 @@ language: python
 env:
 
   matrix:
+  - PYTHON=2.7
   - PYTHON=3.6
 
 before_install:

--- a/binder/environment.yml
+++ b/binder/environment.yml
@@ -19,5 +19,6 @@ dependencies:
   - lz4
   - nbserverproxy
   - click
+  - flake8
   - pip:
     - version-information 

--- a/esmlab/__init__.py
+++ b/esmlab/__init__.py
@@ -2,8 +2,9 @@
 """Top-level package for esmlab."""
 from ._version import get_versions
 from esmlab.accessors import EsmDataArrayAccessor
+from esmlab import climatology
 
-_module_imports = (EsmDataArrayAccessor,)
+_module_imports = (EsmDataArrayAccessor,climatology,)
 __version__ = get_versions()["version"]
 del get_versions
 

--- a/esmlab/__init__.py
+++ b/esmlab/__init__.py
@@ -4,7 +4,7 @@ from ._version import get_versions
 from esmlab.accessors import EsmDataArrayAccessor
 from esmlab import climatology
 
-_module_imports = (EsmDataArrayAccessor,climatology,)
+_module_imports = (EsmDataArrayAccessor, climatology,)
 __version__ = get_versions()["version"]
 del get_versions
 


### PR DESCRIPTION
I want to use some `esmlab` functions rather than rolling my own in [marbl-diags](https://github.com/marbl-ecosys/marbl-diags), but needed to make some small changes first:

1. Allow import of `climatology`
1. Add `flake8` to `environment.yml` so `pytest` would run in my environment
1. Ask travis to test python 2.7 as well
