### PR TITLE
Fix `CondaValueError: pip returned an error` while creating the conda…

### DIFF
--- a/ci/environment-dev-3.6.yml
+++ b/ci/environment-dev-3.6.yml
@@ -14,8 +14,8 @@ dependencies:
   - pytest
   - pytest-cov
   - python=3.6
-  - xarray==0.11.2
+  - xarray==0.11.3
+  - xesmf
   - zarr
   - pip:
     - pytest-lazy-fixture
-    - xesmf

--- a/ci/environment-dev-3.7.yml
+++ b/ci/environment-dev-3.7.yml
@@ -26,8 +26,8 @@ dependencies:
   - sphinx_rtd_theme
   - sphinx>=1.6
   - xarray==0.11.2
+  - xesmf
   - zarr
   - pip:
-    - sphinx_copybutton
     - pytest-lazy-fixture
-    - xesmf
+    - sphinx_copybutton


### PR DESCRIPTION
Documentation build process on Readthedocs is failing. The following error is returned: `CondaValueError: pip returned an error`. This is likely related to https://github.com/rtfd/readthedocs.org/issues/3603 which mentions `memory limit exceeded` as the potential problem. One solution is to install `xesmf` with conda instead of pip. 