### PR TITLE
time_manager: returns ds with original time

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,21 @@
+codecov:
+  max_report_age: off
+
+comment: false
+
+coverage:
+  precision: 2
+  round: down
+  status:
+    project:
+      default:
+       threshold: 0.2
+       if_not_found: success
+    patch:
+      default:
+        enabled: no
+        if_not_found: success
+    changes:
+      default:
+        enabled: no
+        if_not_found: success

--- a/docs/source/api.rst
+++ b/docs/source/api.rst
@@ -34,6 +34,14 @@ Regridding
 .. autosummary::
    regrid.regridder
 
+Utilities
+~~~~~~~~~~~
+
+.. autosummary::
+   utils.time.compute_time_var
+   utils.time.uncompute_time_var
+
+
 
 .. currentmodule:: esmlab.config
 .. autoclass:: set_options
@@ -67,3 +75,8 @@ Regridding
 
    .. automethod:: __init__
    .. automethod:: __call__
+
+.. currentmodule:: esmlab.utils.time
+
+.. autofunction:: compute_time_var
+.. autofunction:: uncompute_time_var

--- a/esmlab/statistics.py
+++ b/esmlab/statistics.py
@@ -5,12 +5,6 @@ import numpy as np
 import xarray as xr
 
 from .utils.common import esmlab_xr_set_options
-from .utils.time import (
-    compute_time_var,
-    time_bound_var,
-    time_year_to_midyeardate,
-    uncompute_time_var,
-)
 from .utils.variables import (
     get_original_attrs,
     get_static_variables,

--- a/esmlab/utils/time.py
+++ b/esmlab/utils/time.py
@@ -1,110 +1,222 @@
 from __future__ import absolute_import, division, print_function
 
+import uuid
 from datetime import datetime
 
 import cftime
 import numpy as np
 import xarray as xr
 
+from .variables import get_variables
 
-def time_bound_var(ds, time_coord_name):
-    tb_name = None
-    tb_dim = None
+DEFAULT_TIME_UNITS = "days since 0001-01-01 00:00:00"
+DEFAULT_CALENDAR = "standard"
 
-    if "bounds" in ds[time_coord_name].attrs:
-        tb_name = ds[time_coord_name].attrs["bounds"]
-    elif "time_bound" in ds:
-        tb_name = "time_bound"
 
-    if tb_name:
-        tb_dim = ds[tb_name].dims[1]
-    return tb_name, tb_dim
+class time_manager(object):
+    """Class to support managing the time coordinate of datasets.
+    """
+
+    def __init__(self, ds, time_coord_name=None):
+
+        self._ds = ds
+        self.orig_time_coord_name = None
+        if time_coord_name is None:
+            self.time_coord_name = self._infer_time_coord_name()
+        else:
+            self.time_coord_name = time_coord_name
+
+        self._infer_time_bound_var()
+        self._compute_time()
+
+    @property
+    def time(self):
+        return self._ds[self.time_coord_name]
+
+    @property
+    def time_attrs(self):
+        """Get the attributes of the time coordinate.
+        """
+        attrs = self.time.attrs
+        encoding = self.time.encoding
+
+        if "units" in attrs:
+            units = attrs["units"]
+        elif "units" in encoding:
+            units = encoding["units"]
+        else:
+            units = None
+
+        if "calendar" in attrs:
+            calendar = attrs["calendar"]
+        elif "calendar" in encoding:
+            calendar = encoding["calendar"]
+        else:
+            calendar = DEFAULT_CALENDAR
+
+        if "bounds" in attrs:
+            bounds = attrs["bounds"]
+        elif "bounds" in encoding:
+            bounds = encoding["bounds"]
+        else:
+            bounds = None
+
+        return {"units": units, "calendar": calendar, "bounds": bounds}
+
+    def _infer_time_coord_name(self):
+        """Infer name for time coordinate in a dataset
+        """
+
+        if "time" in self._ds.variables:
+            return "time"
+
+        unlimited_dims = self._ds.encoding.get("unlimited_dims", None)
+        if len(unlimited_dims) == 1:
+            return list(unlimited_dims)[0]
+        raise ValueError(
+            "Cannot infer `time_coord_name` from multiple unlimited dimensions: %s \n\t\t ***** Please specify time_coord_name to use. *****"
+            % unlimited_dims
+        )
+
+    def _infer_time_bound_var(self):
+        """Infer time_bound variable in a dataset.
+        """
+        self.tb_name = self.time_attrs["bounds"]
+        self.tb_dim = None
+
+        if self.tb_name:
+            self.tb_dim = self._ds[self.tb_name].dims[1]
+
+    def get_time_undecoded(self):
+        """return time undecoded
+        """
+        if self.time.dtype != np.dtype("O"):
+            return self.time
+
+        if not self.time_attrs["units"]:
+            raise ValueError("cannot undecode time")
+
+        # un-decode time
+        time = xr.DataArray(self.time)
+        time.values = cftime.date2num(
+            self.time,
+            units=self.time_attrs["units"],
+            calendar=self.time_attrs["calendar"],
+        )
+        return time
+
+    def get_time_decoded(self, midpoint=True, year_offset=np.nan):
+        """Return time decoded.
+        """
+        # to compute a time midpoint, we need a time_bound variable
+        if midpoint and self.time_bound is None:
+            raise ValueError("cannot compute time midpoint w/o time bounds")
+
+        if midpoint:
+            time_values = self.time_bound.mean(self.tb_dim)
+
+        else:
+            # if time has already been decoded and there's no year_offset,
+            # just return the time as is
+            if self.time.dtype == np.dtype("O"):
+                if np.isnan(year_offset):
+                    return time_values
+
+                # if we need to un-decode time to apply the year_offset,
+                # make sure there are units to do so with
+                time_values = self.get_time_undecoded()
+
+            # time has not been decoded
+            else:
+                time_values = self.time
+
+        if not np.isnan(year_offset):
+            time_values += cftime.date2num(
+                datetime(int(year_offset), 1, 1),
+                units=self.time_attrs["units"],
+                calendar=self.time_attrs["calendar"],
+            )
+
+        time_out = xr.DataArray(self.time)
+        time_out.values = xr.CFTimeIndex(
+            cftime.num2date(
+                time_values,
+                units=self.time_attrs["units"],
+                calendar=self.time_attrs["calendar"],
+            )
+        )
+        return time_out
+
+    def _compute_time(self):
+        """Compute the mid-point of the time bounds.
+        """
+        self.orig_time_coord_name = "t" + uuid.uuid4().hex
+
+        self._ds[self.orig_time_coord_name] = self.get_time_undecoded()
+
+        if self.time_bound is not None:
+            groupby_coord = self.get_time_decoded(midpoint=True)
+
+        else:
+            groupby_coord = self.get_time_decoded(midpoint=False)
+
+        self._ds[self.time_coord_name].values = groupby_coord.values
+
+    def restore_dataset(self, ds):
+        ds[self.time_coord_name].values = ds[self.orig_time_coord_name].values
+        ds = ds.drop(self.orig_time_coord_name)
+        return ds
+
+    @property
+    def time_bound(self):
+        """return time bound, ensuring that it has not been decoded.
+        """
+        if self.tb_name is None:
+            return
+
+        if self._ds[self.tb_name].dtype == np.dtype("O"):
+            tb_value = cftime.date2num(
+                self._ds[self.tb_name],
+                units=self.time_attrs["units"],
+                calendar=self.time_attrs["calendar"],
+            )
+            return xr.DataArray(tb_value, dims=(self.time_coord_name))
+        else:
+            return self._ds[self.tb_name]
+
+    @property
+    def time_bound_diff(self):
+        """Compute the difference between time bounds.
+        """
+        time_bound_diff = xr.ones_like(self.time, dtype=self.time.dtype)
+
+        time_bound_diff.name = self.tb_name + "_diff"
+        time_bound_diff.attrs = {}
+
+        if self.time_bound is not None:
+            time_bound_diff.values = self.time_bound.diff(dim=self.tb_dim)[:, 0]
+            if self.tb_dim in time_bound_diff.coords:
+                time_bound_diff = time_bound_diff.drop(self.tb_dim)
+
+        return time_bound_diff
 
 
 def time_year_to_midyeardate(ds, time_coord_name):
+    """Set the time coordinate to the mid-point of the year.
+    """
     ds[time_coord_name].values = np.array(
         [cftime.datetime(year, 7, 2) for year in ds[time_coord_name]]
     )
     return ds
 
 
-def get_time_attrs(dset, time_coord_name):
-    time = dset[time_coord_name]
-    if "units" in time.attrs:
-        units = time.attrs["units"]
-    elif "units" in time.encoding:
-        units = time.encoding["units"]
-    else:
-        units = "days since 0001-01-01 00:00:00"
-
-    if "calendar" in time.attrs:
-        calendar = time.attrs["calendar"]
-    elif "calendar" in time.encoding:
-        calendar = time.encoding["calendar"]
-    else:
-        calendar = "standard"
-
-    return {"units": units, "calendar": calendar}
+def compute_time_var(ds, midpoint=True, year_offset=np.nan):
+    tm = time_manager(ds)
+    ds[tm.time_coord_name] = tm.get_time_decoded(midpoint, year_offset)
+    return ds
 
 
-def compute_time_var(dset, tb_name, tb_dim, time_coord_name, year_offset=np.nan):
-
-    time_attrs = get_time_attrs(dset, time_coord_name)
-
-    if dset[time_coord_name].dtype != np.dtype("O"):
-        time_values = dset[tb_name].mean(tb_dim)
-
-        if not np.isnan(year_offset):
-            time_values += cftime.date2num(
-                datetime(int(year_offset), 1, 1),
-                time_attrs["units"],
-                time_attrs["calendar"],
-            )
-            dset[time_coord_name].attrs["esmlab_year_offset"] = year_offset
-
-        date = cftime.num2date(
-            time_values, units=time_attrs["units"], calendar=time_attrs["calendar"]
-        )
-
-        dset[time_coord_name].values = xr.CFTimeIndex(date)
-
-    if dset[tb_name].dtype == np.dtype("O"):
-        tb_value = cftime.date2num(
-            dset[tb_name], units=time_attrs["units"], calendar=time_attrs["calendar"]
-        )
-        dset[tb_name].values = tb_value
-
-    return dset
-
-
-def uncompute_time_var(dset, time_coord_name):
-    if dset[time_coord_name].dtype == np.dtype("O"):
-        calendar = "standard"
-        units = "days since 0001-01-01 00:00:00"
-        if "calendar" in dset[time_coord_name].attrs:
-            calendar = dset[time_coord_name].attrs["calendar"]
-
-        if "units" in dset[time_coord_name].attrs:
-            units = dset[time_coord_name].attrs["units"]
-
-        time_values = cftime.date2num(
-            dset[time_coord_name], units=units, calendar=calendar
-        )
-
-        dset[time_coord_name].values = time_values
-    return dset
-
-
-def infer_time_coord_name(ds):
-    """ Infer name for time coordinate in a dataset"""
-    if "time" in ds.variables:
-        return "time"
-
-    unlimited_dims = ds.encoding.get("unlimited_dims", None)
-    if len(unlimited_dims) == 1:
-        return list(unlimited_dims)[0]
-
-    raise ValueError(
-        "Cannot infer `time_coord_name` from multiple unlimited dimensions: %s \n\t\t ***** Please specify time_coord_name to use. *****"
-        % unlimited_dims
-    )
+def uncompute_time_var(ds, midpoint=True, year_offset=np.nan):
+    tm = time_manager(ds)
+    ds[tm.time_coord_name] = tm.get_time_undecoded()
+    return ds

--- a/tests/test_climatology.py
+++ b/tests/test_climatology.py
@@ -18,11 +18,18 @@ from esmlab.datasets import open_dataset
 @pytest.mark.parametrize("ds", ["tiny", "ccsm_pop_sample"])
 def test_compute_climatology_multi(ds):
     dset = open_dataset(ds, decode_times=False)
+    print(dset)
     computed_dset = compute_mon_climatology(dset)
+    print(computed_dset)
+    print()
     assert isinstance(computed_dset, xr.Dataset)
     computed_dset = compute_ann_mean(dset)
+    print(computed_dset)
+    print()
     assert isinstance(computed_dset, xr.Dataset)
     computed_dset = compute_mon_anomaly(dset)
+    print(computed_dset)
+    print()
     assert isinstance(computed_dset, xr.Dataset)
 
 


### PR DESCRIPTION
closes #73 

This was not quite as simple as we expected. While `groupby` works on non-coordinates, in practice it is necessary to do the `groupby` on the time coordinate. xarray (via numpy) cannot do math on cftime axes, so these must be the coordinate over which the `groupby` is applied. The solution is to save the old time coordinate, compute on it, then replace it.

@andersy005, this is ready to go.